### PR TITLE
Adds libLLVM and headers for cross-compilation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,8 @@ RUN wget -O /tmp/libraspberrypi0_1.${RPI_FIRMWARE_VERSION}_armhf.deb \
 RUN wget -O /tmp/libllvm-3.9.deb http://archive.raspberrypi.org/debian/pool/main/l/llvm-toolchain-3.9/libllvm3.9_3.9-4_armhf.deb \
  && wget -O /tmp/libllvm-3.9-dev.deb http://archive.raspberrypi.org/debian/pool/main/l/llvm-toolchain-3.9/llvm-3.9-dev_3.9-4_armhf.deb \
  && dpkg-deb -x	/tmp/libllvm-3.9.deb ${SYSROOT_CROSS}/ \
- && dpkg-deb -x	/tmp/libllvm-3.9-dev.deb ${SYSROOT_CROSS}/
+ && dpkg-deb -x	/tmp/libllvm-3.9-dev.deb ${SYSROOT_CROSS}/ \
+ && rm /tmp/libllvm-3.9.deb /tmp/libllvm-3.9-dev.deb
 
 # SPIV-LLVM
 ENV CLANG_GIT_URL http://github.com/KhronosGroup/SPIR

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,12 @@ RUN wget -O /tmp/libraspberrypi0_1.${RPI_FIRMWARE_VERSION}_armhf.deb \
  && cp -r /usr/include/CL ${SYSROOT_CROSS}/include \
  && apt-get remove opencl-c-headers -y
 
+# LLVM library and headers for linking (ARM version)
+RUN wget -O /tmp/libllvm-3.9.deb http://archive.raspberrypi.org/debian/pool/main/l/llvm-toolchain-3.9/libllvm3.9_3.9-4_armhf.deb \
+ && wget -O /tmp/libllvm-3.9-dev.deb http://archive.raspberrypi.org/debian/pool/main/l/llvm-toolchain-3.9/llvm-3.9-dev_3.9-4_armhf.deb \
+ && dpkg-deb -x	/tmp/libllvm-3.9.deb ${SYSROOT_CROSS}/ \
+ && dpkg-deb -x	/tmp/libllvm-3.9-dev.deb ${SYSROOT_CROSS}/
+
 # SPIV-LLVM
 ENV CLANG_GIT_URL http://github.com/KhronosGroup/SPIR
 ENV SPIRV_GIT_URL http://github.com/KhronosGroup/SPIRV-LLVM.git


### PR DESCRIPTION
To be able to link a cross-compiled VC4C against the libLLVM, we need to provide a version of libLLVM for the destination architecture (raspberry pi) to link against (see https://github.com/doe300/VC4C/issues/29).