### PR TITLE
We need wget and curl for building VC4CL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,8 +38,6 @@ RUN wget -O /tmp/libraspberrypi0_1.${RPI_FIRMWARE_VERSION}_armhf.deb \
  && dpkg-deb -x /tmp/libraspberrypi-dev_1.${RPI_FIRMWARE_VERSION}_armhf.deb ${SYSROOT_CROSS} \
  && rm /tmp/libraspberrypi0_1.${RPI_FIRMWARE_VERSION}_armhf.deb /tmp/libraspberrypi-dev_1.${RPI_FIRMWARE_VERSION}_armhf.deb
 
-RUN apt-get -y remove wget curl
-
 RUN cd /usr/bin && ln -s arm-linux-gnueabihf-g++-6 arm-linux-gnueabihf-g++ \
  && ln -s arm-linux-gnueabihf-gcc-6 arm-linux-gnueabihf-gcc
 


### PR DESCRIPTION
They are both used to fetch the VC4C and VC4CLStdLib packages